### PR TITLE
Fixes moderate nanoid vulnerability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4736,9 +4736,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -10437,9 +10437,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"dev": true
 		},
 		"natural-compare": {


### PR DESCRIPTION
## Change
Updates subdependency `nanoid`.

## Rationale
Used version of `nanoid` has a [moderate vulnerability](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2).

## Impact
No impact expected.

## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
