### PR TITLE
Pointer to where a token is stored, for reverse.

### DIFF
--- a/Proxy/Configuration/Response/Json/index.ts
+++ b/Proxy/Configuration/Response/Json/index.ts
@@ -50,6 +50,7 @@ namespace CardExpires {
 
 export interface Json {
 	card: CardBase | CardMonthYear | CardExpires
+	token?: Selector
 	set: (
 		| {
 				find: Selector
@@ -72,6 +73,7 @@ export namespace Json {
 			value.card.expires
 				? Selector.is(value.card.expires)
 				: value.card.expires == undefined) &&
+			(value.token == undefined || (value.token && Selector.is(value.token))) &&
 			value.set &&
 			Array.isArray(value.set) &&
 			value.set.array.every((element: string | Record<string, any>) => {
@@ -109,6 +111,17 @@ export namespace Json {
 			csc: Selector.get<string>(body, configuration.card.csc),
 			expires: month && year ? [month, year] : [0, 0],
 		}
+	}
+
+	export function extractToken(configuration: Json, body: Record<string, any>): string | undefined {
+		let result: string | undefined
+		if (!configuration.token) {
+			result = undefined
+		} else {
+			result = Selector.get<string>(body, configuration.token)
+		}
+
+		return result
 	}
 	export function process(configuration: Json, token: Card.Token, body: Record<string, any>): Record<string, any> {
 		const masked: Card.Token.Unpacked = Card.Token.unpack(token)


### PR DESCRIPTION
## Change
Added field in config to tell where a token is.


## Rationale
To more easily and more consistently obtain tokens when using reverse proxy.


## Impact
Ability to specify where to look for a token using a config.


## Risk
- [ x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x ] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
