### PR TITLE
add real 8 digit bins to Card

### DIFF
--- a/Card/index.spec.ts
+++ b/Card/index.spec.ts
@@ -50,7 +50,7 @@ describe("@pax2pay/model.Card", () => {
 		expect(
 			model.Card.Token.pack(
 				{
-					pan: "1111111112345890",
+					pan: "4556180012345890",
 					csc: "987",
 					expires: [2, 21],
 				},
@@ -58,7 +58,7 @@ describe("@pax2pay/model.Card", () => {
 				"0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg",
 				"FlBUNQjpk4R9g_dcw6WYzQ"
 			)
-		).toEqual("111111115890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ")
+		).toEqual("455618005890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ")
 	})
 	it("Token.unpack", () => {
 		const token = "4567897890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ"
@@ -74,10 +74,10 @@ describe("@pax2pay/model.Card", () => {
 		})
 	})
 	it("Token.unpack 8 digit bin", () => {
-		const token = "111111117890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ"
+		const token = "455618007890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ"
 		expect(model.Card.Token.unpack(token)).toEqual({
-			masked: "11111111****7890",
-			iin: "11111111",
+			masked: "45561800****7890",
+			iin: "45561800",
 			last4: "7890",
 			expires: [2, 21],
 			key: "1354",
@@ -110,7 +110,7 @@ describe("@pax2pay/model.Card", () => {
 	it("Token.unpack splitted 8 digit bin", () => {
 		expect(
 			model.Card.Token.unpack(
-				"111111117890",
+				"455618007890",
 				"16",
 				"0221",
 				"1354",
@@ -118,8 +118,8 @@ describe("@pax2pay/model.Card", () => {
 				"FlBUNQjpk4R9g_dcw6WYzQ"
 			)
 		).toEqual({
-			masked: "11111111****7890",
-			iin: "11111111",
+			masked: "45561800****7890",
+			iin: "45561800",
 			last4: "7890",
 			expires: [2, 21],
 			key: "1354",
@@ -153,7 +153,7 @@ describe("@pax2pay/model.Card", () => {
 	it("Token.unpack splitted w/ part 8 digit bin", () => {
 		expect(
 			model.Card.Token.unpack(
-				"111111117890",
+				"455618007890",
 				"16",
 				"0221",
 				"1354",
@@ -162,8 +162,8 @@ describe("@pax2pay/model.Card", () => {
 				"pan"
 			)
 		).toEqual({
-			masked: "11111111****7890",
-			iin: "11111111",
+			masked: "45561800****7890",
+			iin: "45561800",
 			last4: "7890",
 			expires: [2, 21],
 			key: "1354",
@@ -187,10 +187,10 @@ describe("@pax2pay/model.Card", () => {
 	})
 	it("Token.unpack w/ part 8 digit bin", () => {
 		const token =
-			"111111117890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ/year"
+			"455618007890/16/0221/1354/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ/year"
 		expect(model.Card.Token.unpack(token)).toEqual({
-			masked: "11111111****7890",
-			iin: "11111111",
+			masked: "45561800****7890",
+			iin: "45561800",
 			last4: "7890",
 			expires: [2, 21],
 			key: "1354",

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -11,8 +11,7 @@ export interface Card {
 }
 export namespace Card {
 	// hardcoded set of eight digit bins
-	// 11111111 is a fake test one
-	const EIGHT_DIGIT_BINS = ["11111111"]
+	const EIGHT_DIGIT_BINS = ["45561800", "45561900", "49299300", "49299400"]
 
 	function findBinLength(pan: string): number {
 		// return from a hardcoded set of eight digit bins, otherwise default 6


### PR DESCRIPTION
## Change
Added the real 8 digit bins to the card class, instead of the test data


## Rationale
So that it can know which bins are 8 digits and which arent


## Impact
Paxpay will be able to correctly show 8 digit bins created through the cde


## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
