### PR TITLE
model-cde#38 - Text replacement fails when value to be replaced is contained elsewhere in the body

### DIFF
--- a/Proxy/Pattern.spec.ts
+++ b/Proxy/Pattern.spec.ts
@@ -22,4 +22,60 @@ describe("@pax2pay/model.Proxy.Pattern", () => {
 		newExample = model.Proxy.Pattern.set(newExample, "csc", "123")
 		expect(model.Proxy.Pattern.get(newExample, "csc")).toEqual("123")
 	})
+
+	it("shouldnt replace itself badly when theres a substring", () => {
+		// the DeploymentID contains a substring of the CVV
+		const rs = `
+		  <soap:Body>
+		    <GetCardResponse
+		      xmlns="http://cpapi.conferma.com/">
+		      <GetCardResult CardPoolName="Online Syndicator Account" DeploymentID="113981428" Type="General">
+		        <General>
+		          <Name>coop</Name>
+		          <ConsumerReference>adfgdafg</ConsumerReference>
+		          <Amount Currency="GBP" Value="382"/>
+		          <PaymentRange EndDate="2023-10-31T00:00:00Z" StartDate="2023-10-24T00:00:00Z"/>
+		        </General>
+		        <Card>
+		          <Name>Coop Travel</Name>
+		          <Number>5555444433332222</Number>
+		          <Type>CA</Type>
+		          <ExpiryDate Month="4" Year="2025"/>
+		          <CVV>139</CVV>
+		          <Provider ID="1" Name="Barclaycard Commercial"/>
+		        </Card>
+		        <Identifiers/>
+		      </GetCardResult>
+		    </GetCardResponse>
+		  </soap:Body>
+		</soap:Envelope>
+		`
+		const expected = `
+		  <soap:Body>
+		    <GetCardResponse
+		      xmlns="http://cpapi.conferma.com/">
+		      <GetCardResult CardPoolName="Online Syndicator Account" DeploymentID="113981428" Type="General">
+		        <General>
+		          <Name>coop</Name>
+		          <ConsumerReference>adfgdafg</ConsumerReference>
+		          <Amount Currency="GBP" Value="382"/>
+		          <PaymentRange EndDate="2023-10-31T00:00:00Z" StartDate="2023-10-24T00:00:00Z"/>
+		        </General>
+		        <Card>
+		          <Name>Coop Travel</Name>
+		          <Number>5555444433332222</Number>
+		          <Type>CA</Type>
+		          <ExpiryDate Month="4" Year="2025"/>
+		          <CVV>token/stuff</CVV>
+		          <Provider ID="1" Name="Barclaycard Commercial"/>
+		        </Card>
+		        <Identifiers/>
+		      </GetCardResult>
+		    </GetCardResponse>
+		  </soap:Body>
+		</soap:Envelope>
+		`
+		const replaced = model.Proxy.Pattern.set(rs, "CVV", "token/stuff")
+		expect(replaced).toEqual(expected)
+	})
 })

--- a/Proxy/Pattern.ts
+++ b/Proxy/Pattern.ts
@@ -44,8 +44,10 @@ export namespace Pattern {
 				const length = match[0].length
 				const firstIndex = match.index + length
 				const nextIndex = data.substring(match.index + length).indexOf("<")
+				const before = data.substring(0, firstIndex)
+				const after = data.substring(firstIndex + nextIndex)
 
-				data = data.replace(data.slice(firstIndex, firstIndex + nextIndex), value)
+				data = before + value + after
 			}
 		}
 


### PR DESCRIPTION
## Change
Bug in text replacement where it would replace the first instance of the desired text in the document, rather than the correct one


## Rationale
It was broken


## Impact
It will be fixed (conferma cde cards will work again)


## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
