### PR TITLE
model-cde#43 - move tokenizing/detokenizing code from worker-cde to model-cde

### DIFF
--- a/Card/Detokenizer/Base.ts
+++ b/Card/Detokenizer/Base.ts
@@ -1,0 +1,91 @@
+import { cryptly } from "cryptly"
+import { Card } from ".."
+
+export abstract class Base {
+	constructor(protected readonly encrypter: cryptly.Encrypter) {}
+	abstract decryptToken(unpacked: Card.Token.Unpacked): Promise<string | undefined>
+
+	async detokenize(token: Card.Token): Promise<(Card & Card.Masked) | string | Card.Expires | number | undefined>
+	async detokenize(
+		masked: string,
+		length: string,
+		expires: string,
+		key: string,
+		value: string,
+		salt: string
+	): Promise<(Card & Card.Masked) | string | Card.Expires | number | undefined>
+	async detokenize(
+		masked: string,
+		length: string,
+		expires: string,
+		key: string,
+		value: string,
+		salt: string,
+		part: Card.Part
+	): Promise<(Card & Card.Masked) | string | Card.Expires | number | undefined>
+	async detokenize(
+		masked: string,
+		length: string,
+		expires: string,
+		key: string,
+		value: string,
+		salt: string,
+		part: "year" | "month"
+	): Promise<number | undefined>
+	async detokenize(
+		masked: string,
+		length: string,
+		expires: string,
+		key: string,
+		value: string,
+		salt: string,
+		part: "expires"
+	): Promise<Card.Expires | undefined>
+	async detokenize(
+		masked: string,
+		length: string,
+		expires: string,
+		key: string,
+		value: string,
+		salt: string,
+		part: "pan" | "csc" | "masked"
+	): Promise<string | undefined>
+	async detokenize(
+		token: string,
+		...argument: string[]
+	): Promise<(Card & Card.Masked) | Card.Masked | string | Card.Expires | number | undefined> {
+		const unpacked = argument.length == 0 ? Card.Token.unpack(token) : Card.Token.unpack([token, ...argument])
+		let result: (Card & Card.Masked) | Card.Masked | string | Card.Expires | number | undefined
+		result = await this.extractFromUnpackedToken(unpacked)
+		if (result)
+			result = !unpacked.part
+				? result
+				: unpacked.part == "month"
+				? result.expires[0]
+				: unpacked.part == "year"
+				? result.expires[1]
+				: (result as Partial<Card> & Card.Masked)[unpacked.part]
+		return result
+	}
+
+	private async extractFromUnpackedToken(
+		unpacked: Card.Token.Unpacked
+	): Promise<Card.Masked | (Card & Card.Masked) | undefined> {
+		let result: string | number | Card.Masked | (Card & Card.Masked) | Card.Expires | undefined
+		if (this.encrypter) {
+			const decrypted = await this.decryptToken(unpacked)
+			if (decrypted == undefined)
+				result = decrypted
+			else {
+				const [pan, csc] = decrypted.split(":")
+				result = {
+					pan,
+					csc,
+					...unpacked,
+				}
+			}
+		} else
+			result = unpacked
+		return result
+	}
+}

--- a/Card/Detokenizer/Rsa.ts
+++ b/Card/Detokenizer/Rsa.ts
@@ -1,0 +1,13 @@
+import { cryptly } from "cryptly"
+import { Card } from "../index"
+import { Base } from "./Base"
+
+export class Rsa extends Base {
+	constructor(protected readonly encrypter: cryptly.Encrypter.Rsa) {
+		super(encrypter)
+	}
+
+	async decryptToken(unpacked: Card.Token.Unpacked): Promise<string | undefined> {
+		return this.encrypter.decrypt(unpacked.encrypted)
+	}
+}

--- a/Card/Detokenizer/index.ts
+++ b/Card/Detokenizer/index.ts
@@ -1,0 +1,7 @@
+import { Base as DetokenizerBase } from "./Base"
+import { Rsa as DetokenizerRsa } from "./Rsa"
+
+export namespace Detokenizer {
+	export const Base = DetokenizerBase
+	export const Rsa = DetokenizerRsa
+}

--- a/Card/Tokenizer/Base.ts
+++ b/Card/Tokenizer/Base.ts
@@ -1,0 +1,18 @@
+import { cryptly } from "cryptly"
+import { Card } from "../index"
+
+export abstract class Base {
+	constructor(protected readonly encrypter: cryptly.Encrypter) {}
+
+	abstract getKeyName(): Promise<string>
+
+	abstract getSaltValue(encrypted: cryptly.Encrypter.Aes.Encrypted | cryptly.Encrypter.Rsa.Encrypted): Promise<string>
+
+	async tokenize(card: Card): Promise<Card.Token | undefined> {
+		const encrypted = await this.encrypter.encrypt(card.pan + ":" + card.csc)
+
+		return (
+			encrypted && Card.Token.pack(card, await this.getKeyName(), encrypted.value, await this.getSaltValue(encrypted))
+		)
+	}
+}

--- a/Card/Tokenizer/Rsa.ts
+++ b/Card/Tokenizer/Rsa.ts
@@ -1,0 +1,31 @@
+import { cryptly } from "cryptly"
+import { Base } from "./Base"
+
+export class Rsa extends Base {
+	constructor(protected readonly encrypter: cryptly.Encrypter.Rsa) {
+		super(encrypter)
+	}
+
+	async getSaltValue(encrypted: cryptly.Encrypter.Rsa.Encrypted): Promise<string> {
+		return "0"
+	}
+
+	async getKeyName(): Promise<string> {
+		let result: string
+		const publicKey = await this.encrypter.export("public")
+
+		if (publicKey)
+			//take a piece in the middle of the key (because keys start and end the same), 43 here,
+			//remove anything that's not a letter and take the first 4 from there and pad if needed
+			result =
+				"RSA" +
+				publicKey
+					.substring(43)
+					.replaceAll(/[/+=0-9]/g, "")
+					.substring(0, 4)
+					.padEnd(4, "Z")
+		else
+			result = ""
+		return result
+	}
+}

--- a/Card/Tokenizer/index.ts
+++ b/Card/Tokenizer/index.ts
@@ -1,0 +1,7 @@
+import { Base as TokenizerBase } from "./Base"
+import { Rsa as TokenizerRsa } from "./Rsa"
+
+export namespace Tokenizer {
+	export const Base = TokenizerBase
+	export const Rsa = TokenizerRsa
+}

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -1,7 +1,9 @@
 import * as isoly from "isoly"
+import { Detokenizer as CardDetokenizer } from "./Detokenizer/index"
 import { Expires as CardExpires } from "./Expires"
 import { Masked as CardMasked } from "./Masked"
 import { Part as CardPart } from "./Part"
+import { Tokenizer as CardTokenizer } from "./Tokenizer/index"
 
 export interface Card {
 	pan: string
@@ -92,6 +94,11 @@ export namespace Card {
 				// 4567897890/16/0221/220101/0ktG52FXmULx7-3mrj0smEWvJWwuJNA9eQNr8O8kBBKy_gvg/FlBUNQjpk4R9g_dcw6WYzQ
 			)
 		}
+
+		export function isRsa(value: string) {
+			return is(value) && unpack(value).key.startsWith("RSA")
+		}
+
 		export type Unpacked = CardMasked & {
 			key: string
 			encrypted: string
@@ -170,4 +177,7 @@ export namespace Card {
 		export const values = CardPart.values
 		export const is = CardPart.is
 	}
+
+	export const Tokenizer = CardTokenizer
+	export const Detokenizer = CardDetokenizer
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"cloudly-http": "^0.0.41",
 				"cloudly-rest": "^0.0.10",
+				"cryptly": "^4.0.2",
 				"gracely": "^0.0.44",
 				"isoly": "^0.1.19"
 			},
@@ -2315,6 +2316,11 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/cryptly": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/cryptly/-/cryptly-4.0.2.tgz",
+			"integrity": "sha512-NLb1bvx2azpC5y8aCrI5WgCpXLjhm/tZOqD1bLeUMWgfRpBYosEtFL9O894gUK1BccFLnu3x4IXmFJFYmg1hfA=="
 		},
 		"node_modules/dashify": {
 			"version": "2.0.0",
@@ -6295,9 +6301,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -8530,6 +8536,11 @@
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
 			}
+		},
+		"cryptly": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/cryptly/-/cryptly-4.0.2.tgz",
+			"integrity": "sha512-NLb1bvx2azpC5y8aCrI5WgCpXLjhm/tZOqD1bLeUMWgfRpBYosEtFL9O894gUK1BccFLnu3x4IXmFJFYmg1hfA=="
 		},
 		"dashify": {
 			"version": "2.0.0",
@@ -11441,9 +11452,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true
 		},
 		"unherit": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 	"dependencies": {
 		"cloudly-http": "^0.0.41",
 		"cloudly-rest": "^0.0.10",
+		"cryptly": "^4.0.2",
 		"gracely": "^0.0.44",
 		"isoly": "^0.1.19"
 	},


### PR DESCRIPTION

## Change
RSA version of tokenizer was added to model-cde (was only available in worker-cde before)


## Rationale
To allow use of RSA tokenizer within ui-cde


## Impact
Should be able to access an RSA tokenizer in ui-cde as well as rewrite the worker-cde (when appropriate) to use it from the model


## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
