### PR TITLE
model-cde#43 - move tokenizing/detokenizing code from worker-cde to model-cde - small adjustments for worker compatibility

### DIFF
--- a/Card/Detokenizer/Base.ts
+++ b/Card/Detokenizer/Base.ts
@@ -56,15 +56,15 @@ export abstract class Base {
 	): Promise<(Card & Card.Masked) | Card.Masked | string | Card.Expires | number | undefined> {
 		const unpacked = argument.length == 0 ? Card.Token.unpack(token) : Card.Token.unpack([token, ...argument])
 		let result: (Card & Card.Masked) | Card.Masked | string | Card.Expires | number | undefined
-		result = await this.extractFromUnpackedToken(unpacked)
-		if (result)
+		const fromUnpacked = await this.extractFromUnpackedToken(unpacked)
+		if (fromUnpacked)
 			result = !unpacked.part
-				? result
+				? fromUnpacked
 				: unpacked.part == "month"
-				? result.expires[0]
+				? fromUnpacked.expires[0]
 				: unpacked.part == "year"
-				? result.expires[1]
-				: (result as Partial<Card> & Card.Masked)[unpacked.part]
+				? fromUnpacked.expires[1]
+				: (fromUnpacked as Partial<Card> & Card.Masked)[unpacked.part]
 		return result
 	}
 

--- a/Card/Detokenizer/index.ts
+++ b/Card/Detokenizer/index.ts
@@ -2,6 +2,8 @@ import { Base as DetokenizerBase } from "./Base"
 import { Rsa as DetokenizerRsa } from "./Rsa"
 
 export namespace Detokenizer {
+	export type Base = DetokenizerBase
 	export const Base = DetokenizerBase
+	export type Rsa = DetokenizerRsa
 	export const Rsa = DetokenizerRsa
 }

--- a/Card/Tokenizer/Base.ts
+++ b/Card/Tokenizer/Base.ts
@@ -4,7 +4,7 @@ import { Card } from "../index"
 export abstract class Base {
 	constructor(protected readonly encrypter: cryptly.Encrypter) {}
 
-	abstract getKeyName(): Promise<string>
+	abstract getKeyName(encrypted?: cryptly.Encrypter.Aes.Encrypted | cryptly.Encrypter.Rsa.Encrypted): Promise<string>
 
 	abstract getSaltValue(encrypted: cryptly.Encrypter.Aes.Encrypted | cryptly.Encrypter.Rsa.Encrypted): Promise<string>
 
@@ -12,7 +12,13 @@ export abstract class Base {
 		const encrypted = await this.encrypter.encrypt(card.pan + ":" + card.csc)
 
 		return (
-			encrypted && Card.Token.pack(card, await this.getKeyName(), encrypted.value, await this.getSaltValue(encrypted))
+			encrypted &&
+			Card.Token.pack(
+				card,
+				await this.getKeyName(encrypted.key ? encrypted : undefined),
+				encrypted.value,
+				await this.getSaltValue(encrypted)
+			)
 		)
 	}
 }

--- a/Card/Tokenizer/Rsa.ts
+++ b/Card/Tokenizer/Rsa.ts
@@ -6,11 +6,11 @@ export class Rsa extends Base {
 		super(encrypter)
 	}
 
-	async getSaltValue(encrypted: cryptly.Encrypter.Rsa.Encrypted): Promise<string> {
+	async getSaltValue(): Promise<string> {
 		return "0"
 	}
 
-	async getKeyName(encrypted?: cryptly.Encrypter.Rsa.Encrypted): Promise<string> {
+	async getKeyName(): Promise<string> {
 		let result: string
 		const publicKey = await this.encrypter.export("public")
 

--- a/Card/Tokenizer/Rsa.ts
+++ b/Card/Tokenizer/Rsa.ts
@@ -10,7 +10,7 @@ export class Rsa extends Base {
 		return "0"
 	}
 
-	async getKeyName(): Promise<string> {
+	async getKeyName(encrypted?: cryptly.Encrypter.Rsa.Encrypted): Promise<string> {
 		let result: string
 		const publicKey = await this.encrypter.export("public")
 

--- a/Card/Tokenizer/index.ts
+++ b/Card/Tokenizer/index.ts
@@ -2,6 +2,8 @@ import { Base as TokenizerBase } from "./Base"
 import { Rsa as TokenizerRsa } from "./Rsa"
 
 export namespace Tokenizer {
+	export type Base = TokenizerBase
 	export const Base = TokenizerBase
+	export type Rsa = TokenizerRsa
 	export const Rsa = TokenizerRsa
 }

--- a/Card/index.spec.ts
+++ b/Card/index.spec.ts
@@ -279,8 +279,11 @@ describe("@pax2pay/model.Card.Tokenizer + Detokenizer", () => {
 		})
 		if (gracely.Error.is(token))
 			fail(token.error)
+		else if (!token)
+			fail()
 		else {
 			expect(model.Card.Token.is(token)).toEqual(true)
+			expect(model.Card.Token.unpack(token).salt).toEqual("0")
 			const detokenizer = new model.Card.Detokenizer.Rsa(encrypter)
 			const card = token && (await detokenizer.detokenize(token))
 			expect(card).toMatchObject({

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -178,6 +178,16 @@ export namespace Card {
 		export const is = CardPart.is
 	}
 
-	export const Tokenizer = CardTokenizer
-	export const Detokenizer = CardDetokenizer
+	export namespace Tokenizer {
+		export type Base = CardTokenizer.Base
+		export const Base = CardTokenizer.Base
+		export type Rsa = CardTokenizer.Rsa
+		export const Rsa = CardTokenizer.Rsa
+	}
+	export namespace Detokenizer {
+		export type Base = CardDetokenizer.Base
+		export const Base = CardDetokenizer.Base
+		export type Rsa = CardDetokenizer.Rsa
+		export const Rsa = CardDetokenizer.Rsa
+	}
 }


### PR DESCRIPTION

## Change
Exported types
Adjusted Base class to allow implementation in worker
Small renaming to make code clearer

## Rationale
The implementation made in worker needed to read the key name differently
Other changes were general improvements


## Impact
The AES implementation can be made in the worker


## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
