### PR TITLE
Support expiry dates starting with year

### DIFF
--- a/Card/Expires/index.spec.ts
+++ b/Card/Expires/index.spec.ts
@@ -11,7 +11,6 @@ describe("Card.Expires", () => {
 
 	it("parse 12/24", () => expect(pax2pay.cde.Card.Expires.parse("12/24")).toEqual([12, 24]))
 	it("parse 1224", () => expect(pax2pay.cde.Card.Expires.parse("1224")).toEqual([12, 24]))
-	it("parse 1224", () => expect(pax2pay.cde.Card.Expires.parse("1224")).toEqual([12, 24]))
 
 	it("parse 122", () => expect(pax2pay.cde.Card.Expires.parse("122")).toEqual([1, 22]))
 	it("parse 5/2023", () => expect(pax2pay.cde.Card.Expires.parse("5/2023")).toEqual([5, 23]))
@@ -21,15 +20,14 @@ describe("Card.Expires", () => {
 	it("parse 2033-07-01T12:34:56", () => expect(pax2pay.cde.Card.Expires.parse("2033-07-01T12:34:56")).toEqual([7, 33]))
 
 	//year first value
-	it("parse 12-24", () => expect(pax2pay.cde.Card.Expires.parse("24-12", false)).toEqual([12, 24]))
+	it("parse 24-12", () => expect(pax2pay.cde.Card.Expires.parse("24-12", false)).toEqual([12, 24]))
 
-	it("parse 12.24", () => expect(pax2pay.cde.Card.Expires.parse("24.12", false)).toEqual([12, 24]))
+	it("parse 24.12", () => expect(pax2pay.cde.Card.Expires.parse("24.12", false)).toEqual([12, 24]))
 
-	it("parse 12/24", () => expect(pax2pay.cde.Card.Expires.parse("24/12", false)).toEqual([12, 24]))
-	it("parse 1224", () => expect(pax2pay.cde.Card.Expires.parse("2412", false)).toEqual([12, 24]))
-	it("parse 1224", () => expect(pax2pay.cde.Card.Expires.parse("2412", false)).toEqual([12, 24]))
+	it("parse 24/12", () => expect(pax2pay.cde.Card.Expires.parse("24/12", false)).toEqual([12, 24]))
+	it("parse 2412", () => expect(pax2pay.cde.Card.Expires.parse("2412", false)).toEqual([12, 24]))
 
-	it("parse 122", () => expect(pax2pay.cde.Card.Expires.parse("221", false)).toEqual([1, 22]))
-	it("parse 5/2023", () => expect(pax2pay.cde.Card.Expires.parse("2023/5", false)).toEqual([5, 23]))
-	it("parse 52023", () => expect(pax2pay.cde.Card.Expires.parse("20235", false)).toEqual([5, 23]))
+	it("parse 221", () => expect(pax2pay.cde.Card.Expires.parse("221", false)).toEqual([1, 22]))
+	it("parse 2023/5", () => expect(pax2pay.cde.Card.Expires.parse("2023/5", false)).toEqual([5, 23]))
+	it("parse 20235", () => expect(pax2pay.cde.Card.Expires.parse("20235", false)).toEqual([5, 23]))
 })

--- a/Card/Expires/index.spec.ts
+++ b/Card/Expires/index.spec.ts
@@ -19,4 +19,17 @@ describe("Card.Expires", () => {
 
 	it("parse 2033-07-01", () => expect(pax2pay.cde.Card.Expires.parse("2033-07-01")).toEqual([7, 33]))
 	it("parse 2033-07-01T12:34:56", () => expect(pax2pay.cde.Card.Expires.parse("2033-07-01T12:34:56")).toEqual([7, 33]))
+
+	//year first value
+	it("parse 12-24", () => expect(pax2pay.cde.Card.Expires.parse("24-12", false)).toEqual([12, 24]))
+
+	it("parse 12.24", () => expect(pax2pay.cde.Card.Expires.parse("24.12", false)).toEqual([12, 24]))
+
+	it("parse 12/24", () => expect(pax2pay.cde.Card.Expires.parse("24/12", false)).toEqual([12, 24]))
+	it("parse 1224", () => expect(pax2pay.cde.Card.Expires.parse("2412", false)).toEqual([12, 24]))
+	it("parse 1224", () => expect(pax2pay.cde.Card.Expires.parse("2412", false)).toEqual([12, 24]))
+
+	it("parse 122", () => expect(pax2pay.cde.Card.Expires.parse("221", false)).toEqual([1, 22]))
+	it("parse 5/2023", () => expect(pax2pay.cde.Card.Expires.parse("2023/5", false)).toEqual([5, 23]))
+	it("parse 52023", () => expect(pax2pay.cde.Card.Expires.parse("20235", false)).toEqual([5, 23]))
 })

--- a/Card/Expires/index.ts
+++ b/Card/Expires/index.ts
@@ -11,14 +11,16 @@ export namespace Expires {
 	export function stringify(expires: Expires): string {
 		return expires[0] + "/" + expires[1]
 	}
-	export function parse(expires: string): Expires | undefined {
+	export function parse(expires: string, monthFirst = true): Expires | undefined {
 		let result;
 		if ((/^\d{4}-\d{2}-\d{2}.*/).test(expires) && new globalThis.Date(expires).toString() != "Invalid Date")
 			result = [ExpiresMonth.parse(expires.substring(5, 7)), ExpiresYear.parse(expires.substring(2, 4))]
 		else {
 			const numbers = expires.replaceAll(/[\.\/-]/g, "")
 			const monthLength = numbers.length % 2 == 1 ? 1: 2
-			result = [ExpiresMonth.parse(numbers.substring(0, monthLength)), ExpiresYear.parse(numbers.substring(monthLength))]
+			result = monthFirst 
+			? [ExpiresMonth.parse(numbers.substring(0, monthLength)), ExpiresYear.parse(numbers.substring(monthLength))]
+			: [ExpiresYear.parse(numbers.substring(numbers.length - monthLength)), ExpiresYear.parse(numbers.substring(0, numbers.length - monthLength))] 
 		}
 		return Expires.is(result) ? result : undefined
 	}

--- a/Proxy/Configuration/Tokenize/Json/Card/Expires.ts
+++ b/Proxy/Configuration/Tokenize/Json/Card/Expires.ts
@@ -2,10 +2,19 @@ import { Selector } from "../../../../Selector"
 import { Base } from "./Base"
 
 export interface Expires extends Base {
-	expires: Selector
+	expires: Selector | [Selector, "YYMM" | "MMYY"]
 }
 export namespace Expires {
 	export function is(value: Expires | any): value is Expires {
-		return typeof value == "object" && value.expires && Selector.is(value.expires) && Base.is(value)
+		return (
+			typeof value == "object" &&
+			value.expires &&
+			(Selector.is(value.expires) ||
+				(Array.isArray(value.expires) &&
+					value.expires.length == 2 &&
+					Selector.is(value.expires[0]) &&
+					(value.expires[1] == "YYMM" || value.expires[1] == "MMYY"))) &&
+			Base.is({ ...value })
+		)
 	}
 }

--- a/Proxy/Configuration/Tokenize/Json/Card/index.spec.ts
+++ b/Proxy/Configuration/Tokenize/Json/Card/index.spec.ts
@@ -16,6 +16,16 @@ const expiresCard = {
 	expires: "expiryDate",
 }
 
+const expiresArrayYearFirstCard = {
+	...baseCard,
+	expires: ["expiryDate", "YYMM"],
+}
+
+const expiresArrayMonthFirstCard = {
+	...baseCard,
+	expires: ["expiryDate", "MMYY"],
+}
+
 describe("Proxy.Configuration.Tokenize.Json.Card", () => {
 	it("Base.is", async () => {
 		expect(Card.Base.is(baseCard)).toBeTruthy()
@@ -29,5 +39,7 @@ describe("Proxy.Configuration.Tokenize.Json.Card", () => {
 		expect(Card.Expires.is(baseCard)).toBeFalsy()
 		expect(Card.Expires.is(monthYearCard)).toBeFalsy()
 		expect(Card.Expires.is(expiresCard)).toBeTruthy()
+		expect(Card.Expires.is(expiresArrayYearFirstCard)).toBeTruthy()
+		expect(Card.Expires.is(expiresArrayMonthFirstCard)).toBeTruthy()
 	})
 })

--- a/Proxy/Configuration/Tokenize/Json/index.ts
+++ b/Proxy/Configuration/Tokenize/Json/index.ts
@@ -29,10 +29,7 @@ export namespace Json {
 				value.card.year &&
 				Selector.is(value.card.year) &&
 				value.card.expires == undefined) ||
-				(value.card.month == undefined &&
-					value.card.year == undefined &&
-					value.card.expires &&
-					Selector.is(value.card.expires)) ||
+				(value.card.month == undefined && value.card.year == undefined && CardType.Expires.is({ ...value.card })) ||
 				(value.card.month == undefined && value.card.year == undefined && value.card.expires == undefined)) &&
 			value.set &&
 			Array.isArray(value.set) &&
@@ -61,7 +58,16 @@ export namespace Json {
 			month = Card.Expires.Month.parse(Selector.get(body, configuration.card.month))
 			year = Card.Expires.Year.parse(Selector.get(body, configuration.card.year))
 		} else if (CardType.Expires.is(configuration.card)) {
-			const monthYear = Card.Expires.parse(Selector.get(body, configuration.card.expires))
+			let selector
+			let monthFirst
+			if (Array.isArray(configuration.card.expires)) {
+				selector = configuration.card.expires[0]
+				monthFirst = configuration.card.expires[1] == "MMYY"
+			} else {
+				selector = configuration.card.expires
+				monthFirst = true
+			}
+			const monthYear = Card.Expires.parse(Selector.get(body, selector), monthFirst)
 			month = monthYear ? monthYear[0] : undefined
 			year = monthYear ? monthYear[1] : undefined
 		}

--- a/Proxy/Configuration/Tokenize/Json/test/configurations.ts
+++ b/Proxy/Configuration/Tokenize/Json/test/configurations.ts
@@ -41,6 +41,26 @@ export const configurations = {
 			},
 		],
 	},
+	expiresYearFirst: {
+		type: "json",
+		url: "asd123",
+		card: {
+			pan: "card.pan",
+			csc: "card.csc",
+			expires: ["card.expires", "YYMM"],
+		},
+		set: [
+			{
+				find: "card.pan",
+				value: "$(masked)",
+			},
+			"card.csc",
+			{
+				find: "card.token",
+				value: "$(token)",
+			},
+		],
+	},
 	noExpires: {
 		type: "json",
 		url: "asd123",

--- a/Proxy/Configuration/Tokenize/Json/test/dataset.ts
+++ b/Proxy/Configuration/Tokenize/Json/test/dataset.ts
@@ -55,6 +55,20 @@ export const dataset = {
 			expires: [2, 2022],
 		},
 	},
+	cardExpiryYearFirstString: {
+		card: {
+			pan: "4567890123457890",
+			csc: "987",
+			expires: "222",
+		},
+	},
+	cardExpiryYearFirstLongString: {
+		card: {
+			pan: "4567890123457890",
+			csc: "987",
+			expires: "20222",
+		},
+	},
 	cardNoExpiry: {
 		card: {
 			pan: "1234123412341234",

--- a/Proxy/Configuration/Tokenize/Json/test/index.spec.ts
+++ b/Proxy/Configuration/Tokenize/Json/test/index.spec.ts
@@ -152,6 +152,32 @@ describe("pax2pay.cde.Proxy.Configuration.Tokenize.Json", () => {
 		})
 	})
 
+	it("extract, expiry year first string", () => {
+		const card = pax2pay.cde.Proxy.Configuration.Tokenize.Json.extract(
+			configurations.expiresYearFirst,
+			dataset.cardExpiryYearFirstString
+		)
+		expect(pax2pay.cde.Card.is(card))
+		expect(card).toEqual({
+			pan: "4567890123457890",
+			csc: "987",
+			expires: [2, 22],
+		})
+	})
+
+	it("extract, expiry year first long string", () => {
+		const card = pax2pay.cde.Proxy.Configuration.Tokenize.Json.extract(
+			configurations.expiresYearFirst,
+			dataset.cardExpiryYearFirstLongString
+		)
+		expect(pax2pay.cde.Card.is(card))
+		expect(card).toEqual({
+			pan: "4567890123457890",
+			csc: "987",
+			expires: [2, 22],
+		})
+	})
+
 	it("extract, date list string 2, 2022", () => {
 		const card = pax2pay.cde.Proxy.Configuration.Tokenize.Json.extract(
 			configurations.monthYear,
@@ -198,6 +224,37 @@ describe("pax2pay.cde.Proxy.Configuration.Tokenize.Json", () => {
 				card: {
 					pan: "pan",
 					csc: "cvv2",
+				},
+				set: [
+					{
+						find: "pan",
+						value: "$(masked)",
+					},
+					"cvv2",
+					{
+						find: "token",
+						value: "$(token)",
+					},
+					{
+						find: "encrypted",
+						value: "$(encrypted)",
+					},
+				],
+			})
+		).toBeTruthy()
+	})
+
+	it("is expiry year first", async () => {
+		expect(
+			jsons.map(item => pax2pay.cde.Proxy.Configuration.Tokenize.Json.is(item)).every(item => item == true)
+		).toBeTruthy()
+		expect(
+			pax2pay.cde.Proxy.Configuration.Tokenize.Json.is({
+				type: "json",
+				card: {
+					pan: "pan",
+					csc: "cvv2",
+					expires: ["expiry", "YYMM"],
 				},
 				set: [
 					{

--- a/Proxy/Configuration/Tokenize/Text/Card/Expires.ts
+++ b/Proxy/Configuration/Tokenize/Text/Card/Expires.ts
@@ -2,10 +2,19 @@ import { Pattern } from "../../../../Pattern"
 import { Base } from "./Base"
 
 export interface Expires extends Base {
-	expires: Pattern
+	expires: Pattern | [Pattern, "YYMM" | "MMYY"]
 }
 export namespace Expires {
 	export function is(value: Expires | any): value is Expires {
-		return typeof value == "object" && value.expires && Pattern.is(value.expires) && Base.is(value)
+		return (
+			typeof value == "object" &&
+			value.expires &&
+			(Pattern.is(value.expires) ||
+				(Array.isArray(value.expires) &&
+					value.expires.length == 2 &&
+					Pattern.is(value.expires[0]) &&
+					(value.expires[1] == "YYMM" || value.expires[1] == "MMYY"))) &&
+			Base.is(value)
+		)
 	}
 }

--- a/Proxy/Configuration/Tokenize/Text/Card/index.spec.ts
+++ b/Proxy/Configuration/Tokenize/Text/Card/index.spec.ts
@@ -31,6 +31,16 @@ const expiresCardOnlyNumber = {
 	expires: "expiryDate",
 }
 
+const expiresArrayYearFirstCard = {
+	...baseCard,
+	expires: ["expiryDate", "YYMM"],
+}
+
+const expiresArrayMonthFirstCard = {
+	...baseCard,
+	expires: ["expiryDate", "MMYY"],
+}
+
 describe("Proxy.Configuration.Tokenize.Json.Card", () => {
 	it("Base.is", async () => {
 		expect(Card.Base.is(baseCard)).toBeTruthy()
@@ -51,5 +61,7 @@ describe("Proxy.Configuration.Tokenize.Json.Card", () => {
 		expect(Card.Expires.is(monthYearCardOnlyNumber)).toBeFalsy()
 		expect(Card.Expires.is(expiresCard)).toBeTruthy()
 		expect(Card.Expires.is(expiresCardOnlyNumber)).toBeTruthy()
+		expect(Card.Expires.is(expiresArrayYearFirstCard)).toBeTruthy()
+		expect(Card.Expires.is(expiresArrayMonthFirstCard)).toBeTruthy()
 	})
 })

--- a/Proxy/Configuration/Tokenize/Text/Plain/test/configurations.ts
+++ b/Proxy/Configuration/Tokenize/Text/Plain/test/configurations.ts
@@ -27,4 +27,30 @@ export const configurations = {
 			},
 		],
 	},
+	expiresYearFirst: {
+		type: "plain",
+		entryDelimiter: "&",
+		equalsDelimiter: "=",
+		url: "asd123",
+		card: {
+			pan: "cardnumber",
+			csc: "csc",
+			expires: ["expiry", "YYMM"],
+		},
+		set: [
+			{
+				find: "cardnumber",
+				value: "$(masked)",
+			},
+			"csc",
+			{
+				find: "token",
+				value: "$(token)",
+			},
+			{
+				find: "asd",
+				value: "$(token)",
+			},
+		],
+	},
 } as Record<string, Plain>

--- a/Proxy/Configuration/Tokenize/Text/Plain/test/dataset.ts
+++ b/Proxy/Configuration/Tokenize/Text/Plain/test/dataset.ts
@@ -1,4 +1,5 @@
 export const dataset = {
 	generic: "cardnumber=1234123412341234&csc=789&asd=qwe&expiry=0925",
+	genericYearFirst: "cardnumber=1234123412341234&csc=789&asd=qwe&expiry=2509",
 	doubleNumber: "cardnumber=1234123412341234&csc=789&cardnumber=1234123412341234&asd=qwe&expiry=0925",
 }

--- a/Proxy/Configuration/Tokenize/Text/Plain/test/index.spec.ts
+++ b/Proxy/Configuration/Tokenize/Text/Plain/test/index.spec.ts
@@ -3,7 +3,7 @@ import { configurations } from "./configurations"
 import { dataset } from "./dataset"
 
 describe("@pax2pay/pax2pay.cde.Proxy.Configuration.Tokenize.TextPlain", () => {
-	it("extract", async () => {
+	it("extract generic", async () => {
 		const data = dataset["generic"]
 		const config = configurations["expires"]
 		expect(pax2pay.cde.Proxy.Configuration.Tokenize.Text.Plain.is(config)).toBeTruthy()
@@ -15,7 +15,18 @@ describe("@pax2pay/pax2pay.cde.Proxy.Configuration.Tokenize.TextPlain", () => {
 			expires: [9, 25],
 		})
 	})
+	it("extract genericYearFirst", async () => {
+		const data = dataset["genericYearFirst"]
+		const config = configurations["expiresYearFirst"]
+		expect(pax2pay.cde.Proxy.Configuration.Tokenize.Text.Plain.is(config)).toBeTruthy()
 
+		const card = pax2pay.cde.Proxy.Configuration.Tokenize.Text.extract(config, data)
+		expect(card).toMatchObject({
+			pan: "1234123412341234",
+			csc: "789",
+			expires: [9, 25],
+		})
+	})
 	it("process regular", async () => {
 		const data = dataset["generic"]
 		const config = configurations["expires"]

--- a/Proxy/Configuration/Tokenize/Text/index.ts
+++ b/Proxy/Configuration/Tokenize/Text/index.ts
@@ -16,7 +16,16 @@ export namespace Text {
 			month = Card.Expires.Month.parse(pattern.extract(body, configuration.card.month))
 			year = Card.Expires.Year.parse(pattern.extract(body, configuration.card.year))
 		} else if (CardType.Expires.is(configuration.card)) {
-			const monthYear = Card.Expires.parse(pattern.extract(body, configuration.card.expires))
+			let selector
+			let monthFirst
+			if (Array.isArray(configuration.card.expires)) {
+				selector = configuration.card.expires[0]
+				monthFirst = configuration.card.expires[1] == "MMYY"
+			} else {
+				selector = configuration.card.expires
+				monthFirst = true
+			}
+			const monthYear = Card.Expires.parse(pattern.extract(body, selector), monthFirst)
 			month = monthYear ? monthYear[0] : undefined
 			year = monthYear ? monthYear[1] : undefined
 		}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "es2021",
+		"target": "ES2021",
 		"module": "es2020",
 		"lib": [
-			"es2021",
+			"ES2021",
 			"webworker"
 		],
 		"allowJs": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "ES2021",
+		"target": "es2021",
 		"module": "es2020",
 		"lib": [
-			"ES2021",
+			"es2021",
 			"webworker"
 		],
 		"allowJs": true,


### PR DESCRIPTION
## Change
Added support for configurations handling expiry dates which starts with year and ends with month


## Rationale
New provider returns expiry date in format "YYMM"


## Impact
Expiry date can be read from new provider


## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
