### PR TITLE
Prettierx vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"eslint-plugin-prettierx": "github:utily/eslint-plugin-prettierx#utily-20240516",
 				"eslint-plugin-simple-import-sort": "^12.1.0",
 				"jest": "^29.7.0",
-				"prettierx": "github:utily/prettierx#utily-20240516",
+				"prettierx": "github:utily/prettierx#utily-20240618",
 				"rimraf": "^5.0.7",
 				"ts-jest": "^29.1.4",
 				"typescript": "^5.4.5"
@@ -53,15 +53,16 @@
 			}
 		},
 		"node_modules/@angular/compiler": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.1.1.tgz",
-			"integrity": "sha512-QV56c+A18vdY8AB/SoWq0UkHhJxYDWY+VUY75RM2dxcsXoNeO5FTCjBRkA7yMiX6Q6cahH2ivC7tmqVU2mYHuA==",
+			"version": "21.0.2",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.0.2.tgz",
+			"integrity": "sha512-Rs69yqT1M+l0DqAAZcGDt2TntKAPyldEViq3GQHbkM1W4f/hoRgBRsE6StxvP6wszW6VVHH3uQQdyeZV8Z4rpw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"tslib": "^2.2.0"
+				"tslib": "^2.3.0"
 			},
 			"engines": {
-				"node": "^12.14.1 || >=14.0.0"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@angular/compiler/node_modules/tslib": {
@@ -6628,12 +6629,12 @@
 			}
 		},
 		"@angular/compiler": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.1.1.tgz",
-			"integrity": "sha512-QV56c+A18vdY8AB/SoWq0UkHhJxYDWY+VUY75RM2dxcsXoNeO5FTCjBRkA7yMiX6Q6cahH2ivC7tmqVU2mYHuA==",
+			"version": "21.0.2",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.0.2.tgz",
+			"integrity": "sha512-Rs69yqT1M+l0DqAAZcGDt2TntKAPyldEViq3GQHbkM1W4f/hoRgBRsE6StxvP6wszW6VVHH3uQQdyeZV8Z4rpw==",
 			"dev": true,
 			"requires": {
-				"tslib": "^2.2.0"
+				"tslib": "^2.3.0"
 			},
 			"dependencies": {
 				"tslib": {
@@ -10301,9 +10302,9 @@
 		"prettierx": {
 			"version": "git+ssh://git@github.com/utily/prettierx.git#f2d44e031e2ad8bf665f78191ab3167ff63ebb03",
 			"dev": true,
-			"from": "prettierx@github:utily/prettierx#utily-20240516",
+			"from": "prettierx@github:utily/prettierx#utily-20240618",
 			"requires": {
-				"@angular/compiler": "12.1.1",
+				"@angular/compiler": "21.0.2",
 				"@babel/code-frame": "7.14.5",
 				"@babel/parser": "7.14.7",
 				"@brodybits/remark-parse": "8.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"eslint-plugin-prettierx": "github:utily/eslint-plugin-prettierx#utily-20240516",
 				"eslint-plugin-simple-import-sort": "^12.1.0",
 				"jest": "^29.7.0",
-				"prettierx": "github:utily/prettierx#utily-20240618",
+				"prettierx": "github:utily/prettierx#utily-20240516",
 				"rimraf": "^5.0.7",
 				"ts-jest": "^29.1.4",
 				"typescript": "^5.4.5"
@@ -10302,7 +10302,7 @@
 		"prettierx": {
 			"version": "git+ssh://git@github.com/utily/prettierx.git#f2d44e031e2ad8bf665f78191ab3167ff63ebb03",
 			"dev": true,
-			"from": "prettierx@github:utily/prettierx#utily-20240618",
+			"from": "prettierx@github:utily/prettierx#utily-20240516",
 			"requires": {
 				"@angular/compiler": "21.0.2",
 				"@babel/code-frame": "7.14.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"eslint-plugin-prettierx": "github:utily/eslint-plugin-prettierx#utily-20240516",
 		"eslint-plugin-simple-import-sort": "^12.1.0",
 		"jest": "^29.7.0",
-		"prettierx": "github:utily/prettierx#utily-20240516",
+		"prettierx": "github:utily/prettierx#utily-20240618",
 		"rimraf": "^5.0.7",
 		"ts-jest": "^29.1.4",
 		"typescript": "^5.4.5"
@@ -76,6 +76,7 @@
 		"isoly": "^2.3.10"
 	},
 	"overrides": {
-		"semver": "7.5.3"
+		"semver": "7.5.3",
+		"@angular/compiler": "21.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"eslint-plugin-prettierx": "github:utily/eslint-plugin-prettierx#utily-20240516",
 		"eslint-plugin-simple-import-sort": "^12.1.0",
 		"jest": "^29.7.0",
-		"prettierx": "github:utily/prettierx#utily-20240618",
+		"prettierx": "github:utily/prettierx#utily-20240516",
 		"rimraf": "^5.0.7",
 		"ts-jest": "^29.1.4",
 		"typescript": "^5.4.5"


### PR DESCRIPTION
## Change
Added an override for package with vulnerability


## Rationale
There was a patched version of affected package, so we can use that


## Impact
No vulnerability, it should work as before


## Risk
- [x] The change does not increase the risk to the system and does therefore not require any extra risk analysis.
- [ ] A separate risk analysis has been performed and is linked below.


## Rollback
- [x] Rollback is performed by reverting the merge and redeploy.
- [ ] Rollback of this change requires special actions as outlined below.
